### PR TITLE
Update to how hostnames work

### DIFF
--- a/ansible/tasks/terraform/create.yml
+++ b/ansible/tasks/terraform/create.yml
@@ -29,7 +29,8 @@
 
     - name: Add each deployed digitalocean host to ansible inventory
       ansible.builtin.add_host:
-        hostname: "{{ item.value['vm'][0]['ipv4_address'] }}"
+        hostname: "{{ item.value['vm'][0]['name'] }}"
+        ansible_host: "{{ item.value['vm'][0]['ipv4_address'] }}"
         groups: "{{ item.value['vm'][0]['tags'] }}"
       changed_when: false
       with_dict: "{{ terraform_infra.outputs['digitalocean_vms'].value }}"
@@ -37,7 +38,8 @@
 
     - name: Add each deployed hetzner host to ansible inventory
       ansible.builtin.add_host:
-        hostname: "{{ item.value['vm'][0]['ipv4_address'] }}"
+        hostname: "{{ item.value['vm'][0]['name'] }}"      
+        ansible_host: "{{ item.value['vm'][0]['ipv4_address'] }}"
         groups: "{{ item.value['vm'][0]['labels'].keys() }}"
       changed_when: false
       with_dict: "{{ terraform_infra.outputs['hetzner_vms'].value }}"

--- a/ansible/templates/terraform.tfvars.j2
+++ b/ansible/templates/terraform.tfvars.j2
@@ -16,7 +16,7 @@ digitalocean_servers = {
 {% endif %}
 {% if 'image' in dict_item %}    image = "{{dict_item['image']}}"
 {% endif %}
-{% if 'name' in dict_item %}    name = "{{dict_item['name']}}"
+{% if 'hostname' in dict_item %}    hostname = "{{dict_item['hostname']}}"
 {% endif %}
 {% if 'region' in dict_item %}    region = "{{dict_item['region']}}"
 {% endif %}
@@ -56,7 +56,7 @@ hetzner_servers = {
 {% endif %}
 {% if 'image' in dict_item %}    image = "{{dict_item['image']}}"
 {% endif %}
-{% if 'name' in dict_item %}    name = "{{dict_item['name']}}"
+{% if 'hostname' in dict_item %}    hostname = "{{dict_item['hostname']}}"
 {% endif %}
 {% if 'location' in dict_item %}    location = "{{dict_item['location']}}"
 {% endif %}

--- a/terraform/digitalocean.tf
+++ b/terraform/digitalocean.tf
@@ -11,7 +11,7 @@ variable "digitalocean_enabled" {
 variable "digitalocean_servers" {
   description = "A map contaning server(s) that should be created."
   type = map(object({
-    name               = string
+    hostname           = optional(string)
     size               = optional(string)
     tags               = list(string)
     image              = optional(string)
@@ -22,7 +22,6 @@ variable "digitalocean_servers" {
   }))
   default = {
     "host1" = {
-      name = "host1"
       tags = ["terraform"]
     }
   }
@@ -59,11 +58,10 @@ module "digitalocean_vm" {
   module_enabled = var.digitalocean_enabled
   for_each       = local.digitalocean_servers
 
-  project_name      = var.project_name
   root_username     = var.root_username
   root_ssh_key_path = var.root_ssh_key_path
 
-  server_name               = each.value.name
+  server_hostname           = each.value.hostname
   server_tags               = each.value.tags
   server_size               = each.value.size
   server_image              = each.value.image

--- a/terraform/digitalocean/vm/main.tf
+++ b/terraform/digitalocean/vm/main.tf
@@ -1,3 +1,9 @@
+resource "random_pet" "name" {
+  count = var.module_enabled ? 1 : 0 # only run if this variable is true
+  
+  length = 2
+}
+
 resource "random_string" "name" {
   count = var.module_enabled ? 1 : 0 # only run if this variable is true
     
@@ -6,12 +12,17 @@ resource "random_string" "name" {
   upper   = false
 }
 
+locals {
+  # if server_hostname is null (which is the default value), generate a random hostname with random_pet and random_string
+  server_hostname = var.server_hostname != null ? var.server_hostname : "${random_pet.name[0].id}-${random_string.name[0].result}" # [0] selector is required due the `count = var.module_enabled` trick.
+}
+
 resource "digitalocean_droplet" "main" {
   count = var.module_enabled ? 1 : 0 # only run if this variable is true
 
+  name               = local.server_hostname
   image              = var.server_image
   tags               = flatten(var.server_tags)
-  name               = "${var.project_name}-${var.server_name}-${terraform.workspace}-${random_string.name[0].result}"
   region             = var.server_region
   size               = var.server_size
   ipv6               = var.server_ipv6
@@ -20,13 +31,13 @@ resource "digitalocean_droplet" "main" {
   ssh_keys           = var.server_ssh_keys
 }
 
-resource "null_resource" "ssh_check" {   # Ensure that SSH is ready and accepting connections on all hosts.
+resource "null_resource" "ssh_check" {   # ensure that SSH is ready and accepting connections on all hosts.
   count = var.module_enabled ? 1 : 0 # only run if this variable is true
 
   connection {
     type        = "ssh"
     user        = var.root_username
-    host        = digitalocean_droplet.main[0].ipv4_address
+    host        = digitalocean_droplet.main[0].ipv4_address # [0] selector is required due the `count = var.module_enabled` trick.
     private_key = file("${var.root_ssh_key_path}")
   }
 

--- a/terraform/digitalocean/vm/variables.tf
+++ b/terraform/digitalocean/vm/variables.tf
@@ -7,8 +7,8 @@ variable "project_name" {
   default = "testing"
 }
 
-variable "server_name" {
-  default = "host1"
+variable "server_hostname" {
+  default = null
 }
 
 variable "server_image" {

--- a/terraform/hetzner.tf
+++ b/terraform/hetzner.tf
@@ -11,7 +11,7 @@ variable "hetzner_enabled" {
 variable "hetzner_servers" {
   description = "A map contaning server(s) that should be created."
   type = map(object({
-    name        = string
+    hostname    = optional(string)
     server_type = optional(string)
     labels      = map(string)
     image       = optional(string)
@@ -20,7 +20,6 @@ variable "hetzner_servers" {
   }))
   default = {
     "host1" = {
-      name   = "host1"
       labels = { terraform = "" }
     }
   }
@@ -57,16 +56,15 @@ module "hetzner_vm" {
   module_enabled = var.hetzner_enabled
   for_each       = local.hetzner_servers
 
-  project_name      = var.project_name
   root_username     = var.root_username
   root_ssh_key_path = var.root_ssh_key_path
 
-  server_name        = each.value.name
+  server_hostname    = each.value.hostname
   server_labels      = each.value.labels
   server_server_type = each.value.server_type
   server_image       = each.value.image
   server_location    = each.value.location
-  
+
   server_backups     = each.value.backups
   server_ssh_keys    = [local.hetzner_ssh_key]
 }

--- a/terraform/hetzner/vm/main.tf
+++ b/terraform/hetzner/vm/main.tf
@@ -1,3 +1,10 @@
+resource "random_pet" "name" {
+  count = var.module_enabled ? 1 : 0 # only run if this variable is true
+  
+  length = 2
+}
+
+
 resource "random_string" "name" {
   count = var.module_enabled ? 1 : 0 # only run if this variable is true
 
@@ -6,11 +13,16 @@ resource "random_string" "name" {
   upper   = false
 }
 
+locals {
+  # if server_hostname is null (which is the default value), generate a random hostname with random_pet and random_string
+  server_hostname = var.server_hostname != null ? var.server_hostname : "${random_pet.name[0].id}-${random_string.name[0].result}" # [0] selector is required due the `count = var.module_enabled` trick.
+}
+
 resource "hcloud_server" "main" {
   count = var.module_enabled ? 1 : 0 # only run if this variable is true
 
+  name        = local.server_hostname
   labels      = var.server_labels
-  name        = "${var.project_name}-${var.server_name}-${terraform.workspace}-${random_string.name[0].result}"
   image       = var.server_image
   server_type = var.server_server_type
   location    = var.server_location
@@ -18,13 +30,13 @@ resource "hcloud_server" "main" {
   ssh_keys    = var.server_ssh_keys
 }
 
-resource "null_resource" "ssh_check" { # Ensure that SSH is ready and accepting connections on all hosts.
+resource "null_resource" "ssh_check" { # ensure that SSH is ready and accepting connections on all hosts.
   count = var.module_enabled ? 1 : 0 # only run if this variable is true
   
   connection {
     type        = "ssh"
     user        = var.root_username
-    host        = hcloud_server.main[0].ipv4_address
+    host        = hcloud_server.main[0].ipv4_address # [0] selector is required due the `count = var.module_enabled` trick.
     private_key = file("${var.root_ssh_key_path}")
   }
 

--- a/terraform/hetzner/vm/variables.tf
+++ b/terraform/hetzner/vm/variables.tf
@@ -7,8 +7,8 @@ variable "project_name" {
   default = "testing"
 }
 
-variable "server_name" {
-  default = "host1"
+variable "server_hostname" {
+  default = null
 }
 
 variable "server_labels" {


### PR DESCRIPTION
- [x] If a hostname is undefined in the host_list var for a VM, generate a random hostname based of `random_pet` and `random_string`, if hostname is set, use the specified hostname.
- [x] Use hostname is ansible inventory as alias so this is reflected in playbook runs output.

old
```
PLAY RECAP **********************************************************************************
10.13.37.10 : ok=1 changed=0 unreachable=0 failed=0 skipped=0 rescued=0 ignored=0
```

new
```
PLAY RECAP **********************************************************************************
sacred-anteater-z6us47 : ok=1 changed=0 unreachable=0 failed=0 skipped=0 rescued=0 ignored=0
```